### PR TITLE
Re-add sickness openbsd builder

### DIFF
--- a/tahoe/master.cfg
+++ b/tahoe/master.cfg
@@ -376,11 +376,11 @@ b.append(BuilderConfig(name="Markus slackware64 stable",
                        tags=[TAG_SUPPORTED],
                        ))
 
-b.append(BuilderConfig(name="Sickness OpenBSD 6.3",                           
-                       slavenames=["sickness-openbsd"],                       
-                       factory=make_tox_factory(),                            
-                       tags=[TAG_UNSUPPORTED],                                
-                       ))             
+b.append(BuilderConfig(name="Sickness OpenBSD 6.3",
+                       slavenames=["sickness-openbsd"],
+                       factory=make_tox_factory(),
+                       tags=[TAG_UNSUPPORTED],
+                       ))
 
 b.append(BuilderConfig(name="OS-X 10.13",
                        slavenames=["warner-mac-tv"],

--- a/tahoe/master.cfg
+++ b/tahoe/master.cfg
@@ -376,6 +376,12 @@ b.append(BuilderConfig(name="Markus slackware64 stable",
                        tags=[TAG_SUPPORTED],
                        ))
 
+b.append(BuilderConfig(name="Sickness OpenBSD 6.2",                           
+                       slavenames=["sickness-openbsd"],                       
+                       factory=make_tox_factory(),                            
+                       tags=[TAG_UNSUPPORTED],                                
+                       ))             
+
 b.append(BuilderConfig(name="OS-X 10.13",
                        slavenames=["warner-mac-tv"],
                        factory=make_tox_factory(do_osx=True),

--- a/tahoe/master.cfg
+++ b/tahoe/master.cfg
@@ -376,7 +376,7 @@ b.append(BuilderConfig(name="Markus slackware64 stable",
                        tags=[TAG_SUPPORTED],
                        ))
 
-b.append(BuilderConfig(name="Sickness OpenBSD 6.2",                           
+b.append(BuilderConfig(name="Sickness OpenBSD 6.3",                           
                        slavenames=["sickness-openbsd"],                       
                        factory=make_tox_factory(),                            
                        tags=[TAG_UNSUPPORTED],                                


### PR DESCRIPTION
sickness still wants to provide this slave and it is currently online (actually, the slave configuration was never removed, only the builder).

So, put the builder back.
