### PR TITLE
Remove the builder configuration

### DIFF
--- a/tahoe/master.cfg
+++ b/tahoe/master.cfg
@@ -395,13 +395,6 @@ b.append(BuilderConfig(name="OS-X 10.13",
                        tags=[TAG_SUPPORTED],
                        ))
 
-# The Raspberry Pi is not fast (even the "3" model). Takes 50min.
-b.append(BuilderConfig(name="Warner rpi3",
-                       slavenames=["warner-redpi"],
-                       factory=make_tox_factory(),
-                       tags=[TAG_SUPPORTED],
-                       ))
-
 b_other = []
 
 b_other.append(BuilderConfig(name="tarballs",


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2983

The slave is not actually decommissioned, of course.  Only Brian can really do that.  Also, I've left the credentials in place because there doesn't seem to be a connection backoff on authentication failure.  Removing the credentials results in a failed authentication attempt every 3 seconds.
